### PR TITLE
Refactor `install_driver/tasks/ubuntu.yaml`

### DIFF
--- a/install_driver/tasks/ubuntu.yaml
+++ b/install_driver/tasks/ubuntu.yaml
@@ -33,6 +33,15 @@
   ansible.builtin.apt:
     deb: "https://developer.download.nvidia.com/compute/cuda/repos/{{ distrib_repo_name }}/{{ arch_repo_name }}/cuda-keyring_1.0-1_all.deb"
 
+- name: Unmark CUDA and driver packages as hold (Ubuntu)
+  ansible.builtin.dpkg_selections:
+    selection: install # install corresponds to "unhold"
+    name: "{{ item }}"
+  # The expression below appends '-<unhold_driver_version>'
+  # to every item in the 'pkgs' variable
+  loop: "{{ pkgs | product(['-' + unhold_driver_version]) | map('join') | list }}"
+  when: unhold_driver_version is defined
+
 - name: Install driver (Ubuntu)
   ansible.builtin.apt:
     allow_downgrade: yes
@@ -46,6 +55,6 @@
   ansible.builtin.dpkg_selections:
     selection: hold
     name: "{{ item }}"
-  # The expression below appends '-<major_driver_version>
+  # The expression below appends '-<major_driver_version>'
   # to every item in the 'pkgs' variable
   loop: "{{ pkgs | product(['-' + major_driver_version]) | map('join') | list }}"

--- a/install_driver/tasks/ubuntu.yaml
+++ b/install_driver/tasks/ubuntu.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Register distribution repository name (Ubuntu)
   ansible.builtin.set_fact:
     distrib_repo_name: "ubuntu{{ ansible_distribution_version | replace('.', '') }}"
@@ -7,6 +6,28 @@
 - name: Register driver major version (Ubuntu)
   ansible.builtin.set_fact:
     major_driver_version: "{{ driver_version.split('.')[0] }}"
+
+- name: Register common CUDA driver packages
+  ansible.builtin.set_fact:
+    pkgs:
+      - libnvidia-cfg1
+      - libnvidia-compute
+      - libnvidia-decode
+      - libnvidia-encode
+      - libnvidia-extra
+      - libnvidia-fbc1
+      - libnvidia-gl
+      - nvidia-compute-utils
+      - nvidia-dkms
+      - nvidia-driver
+      - nvidia-kernel-source
+      - nvidia-utils
+      - xserver-xorg-video-nvidia
+
+- name: Append conditional CUDA driver packages (>=450,<=470)
+  when: (major_driver_version|int) >=450 and (major_driver_version|int) <= 470
+  ansible.builtin.set_fact:
+    pkgs: "{{ pkgs + ['libnvidia-ifr1'] }}"
 
 - name: Install cuda-keyring package (Ubuntu)
   ansible.builtin.apt:
@@ -18,36 +39,14 @@
     allow_downgrade: yes
     autoremove: yes
     update_cache: yes
-    pkg:
-      - "libnvidia-cfg1-{{ major_driver_version }}={{ driver_version }}-*"
-      - "libnvidia-compute-{{ major_driver_version }}={{ driver_version }}-*"
-      - "libnvidia-decode-{{ major_driver_version }}={{ driver_version }}-*"
-      - "libnvidia-encode-{{ major_driver_version }}={{ driver_version }}-*"
-      - "libnvidia-extra-{{ major_driver_version }}={{ driver_version }}-*"
-      - "libnvidia-fbc1-{{ major_driver_version }}={{ driver_version }}-*"
-      - "libnvidia-gl-{{ major_driver_version }}={{ driver_version }}-*"
-      - "nvidia-compute-utils-{{ major_driver_version }}={{ driver_version }}-*"
-      - "nvidia-dkms-{{ major_driver_version }}={{ driver_version }}-*"
-      - "nvidia-driver-{{ major_driver_version }}={{ driver_version }}-*"
-      - "nvidia-kernel-source-{{ major_driver_version }}={{ driver_version }}-*"
-      - "nvidia-utils-{{ major_driver_version }}={{ driver_version }}-*"
-      - "xserver-xorg-video-nvidia-{{ major_driver_version }}={{ driver_version }}-*"
+    # The expression below appends '-<major_driver_version>=<driver_version>-*'
+    # to every item in the 'pkgs' variable
+    pkg: "{{ pkgs | product(['-' + major_driver_version + '=' + driver_version + '-*']) | map('join') | list }}"
 
 - name: Mark CUDA and driver packages as hold (Ubuntu)
   ansible.builtin.dpkg_selections:
     selection: hold
     name: "{{ item }}"
-  loop:
-      - "libnvidia-cfg1-{{ major_driver_version }}"
-      - "libnvidia-compute-{{ major_driver_version }}"
-      - "libnvidia-decode-{{ major_driver_version }}"
-      - "libnvidia-encode-{{ major_driver_version }}"
-      - "libnvidia-extra-{{ major_driver_version }}"
-      - "libnvidia-fbc1-{{ major_driver_version }}"
-      - "libnvidia-gl-{{ major_driver_version }}"
-      - "nvidia-compute-utils-{{ major_driver_version }}"
-      - "nvidia-dkms-{{ major_driver_version }}"
-      - "nvidia-driver-{{ major_driver_version }}"
-      - "nvidia-kernel-source-{{ major_driver_version }}"
-      - "nvidia-utils-{{ major_driver_version }}"
-      - "xserver-xorg-video-nvidia-{{ major_driver_version }}"
+  # The expression below appends '-<major_driver_version>
+  # to every item in the 'pkgs' variable
+  loop: "{{ pkgs | product(['-' + major_driver_version]) | map('join') | list }}"

--- a/install_driver/tasks/ubuntu.yaml
+++ b/install_driver/tasks/ubuntu.yaml
@@ -35,7 +35,6 @@
 
 - name: Install driver (Ubuntu)
   ansible.builtin.apt:
-    allow_change_held_packages: yes
     allow_downgrade: yes
     autoremove: yes
     update_cache: yes

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -1,0 +1,4 @@
+# This file is required for Ansible Galaxy
+galaxy_info:
+  company: NVIDIA
+  description: Common Ansible roles for the RAPIDS team at NVIDIA


### PR DESCRIPTION
When provisioning a new driver `450` machine recently, I ran into an error that said an incompatible version of `libnvidia-ifr1` was going to be installed.

Adding `libnvidia-ifr1` to the existing list of dependencies resolved this.

However, I then proceeded to provision a driver `495` machine and received an error message stating that the `libnvidia-ifr1` package wasn't available for driver `495`.

To account for the discrepancy in packages between driver `450` and `495` machines, I've refactored `install_driver/tasks` to include:

- a list of common packages that should be used for all driver versions
- a separate list of packages (containing only `libnvidia-ifr1` at this time) that should be conditionally appended to the common packages
  - the condition for when `libnvidia-ifr1` should be appended was determined to be `470>= driver_version >=450`

Additionally, I've added a new conditional task, `Unmark CUDA and driver packages as hold`.

This task is used for upgrading driver versions on nodes. It will "unhold" `apt` packages based on the value of the `unhold_driver_version` variable. e.g.:

```sh
ansible-playbook \
  -e unhold_driver_version=495 \
  --limit=k8s-node-7 \
  ansible/run.yaml
```