### PR TITLE
Do not register NVCT for Docker if not installed

### DIFF
--- a/install_nvct/tasks/main.yaml
+++ b/install_nvct/tasks/main.yaml
@@ -19,6 +19,11 @@
       group: root
     when: "register_nvidia_runtime is defined and register_nvidia_runtime"
 
+  - name: Check if Docker is installed
+    ansible.builtin.command: docker --version
+    register: check_docker_installed
+    ignore_errors: yes
+
   - name: Register NVIDIA runtime (docker)
     ansible.builtin.copy:
       src: "daemon.json"
@@ -26,5 +31,5 @@
       mode: 0644
       owner: root
       group: root
-    when: "register_nvidia_runtime is defined and register_nvidia_runtime"
+    when: "check_docker_installed.rc == 0 and register_nvidia_runtime is defined and register_nvidia_runtime"
   when: "gpu_node is defined and gpu_node"


### PR DESCRIPTION
Starting with Kubernetes 1.25, `docker` is not installed in EKS AMIs as the default container runtime is `containerd`

Tested with https://github.com/rapidsai/packer-templates/pull/9